### PR TITLE
Feature.migrate to inheritance 24

### DIFF
--- a/f5_os_test/infrastructure.py
+++ b/f5_os_test/infrastructure.py
@@ -16,8 +16,6 @@
 from f5.bigip import BigIP
 import pytest
 
-from neutronclient.v2_0 import client
-
 
 def pytest_addoption(parser):
     parser.addoption("--bigip", action="store",
@@ -50,6 +48,5 @@ def nclientmanager(request, polling_neutronclient):
         'tenant_name': 'testlab',
         'auth_url': auth_url}
 
-    neutronclient = client.Client(**nclient_config)
-    pnc = polling_neutronclient(neutronclient)
+    pnc = polling_neutronclient(**nclient_config)
     return pnc


### PR DESCRIPTION
@pskergan 

This pull request contains code to migrate from the **get_attr**, hasattr, getattr pattern to standard inheritance.    This seems safer, and more readable.

NOTE:  There's also a minor bufix in `delete_all_listeners`.
