### PR TITLE
Adding support for Heat, Glance, Keystone fixtures

### DIFF
--- a/f5_os_test/heat_client_utils.py
+++ b/f5_os_test/heat_client_utils.py
@@ -1,0 +1,51 @@
+# Copyright 2015-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+import pytest
+
+
+def get_template_file(template_file):
+    file = open(template_file)
+    template_str = file.read()
+    file.close()
+    return template_str
+
+
+def cleanup_stack_if_exists(heat_client, template_name):
+    stacks = heat_client.stacks.list()
+    for stack in stacks:
+        if stack.stack_name == template_name:
+            heat_client.delete_stack(stack.id)
+
+
+@pytest.fixture
+def HeatStack(heatclientmanager, request):
+    '''Fixture for creating/deleting a heat stack.'''
+    def manage_stack(template_file, template_name, parameters={}):
+        def teardown():
+            heatclientmanager.delete_stack(stack.id)
+
+        template = get_template_file(template_file)
+        config = {}
+        config['stack_name'] = template_name
+        config['template'] = template
+        config['parameters'] = parameters
+        # Call delete before create, in case previous teardown failed
+        cleanup_stack_if_exists(heatclientmanager, template_name)
+        stack = heatclientmanager.create_stack(config)
+        request.addfinalizer(teardown)
+        return heatclientmanager, stack
+    return manage_stack

--- a/f5_os_test/heat_client_utils.py
+++ b/f5_os_test/heat_client_utils.py
@@ -17,11 +17,11 @@
 import pytest
 
 
-def get_template_file(template_file):
-    file = open(template_file)
-    template_str = file.read()
+def get_file_contents(file_path):
+    file = open(file_path)
+    file_contents = file.read()
     file.close()
-    return template_str
+    return file_contents
 
 
 def cleanup_stack_if_exists(heat_client, template_name):
@@ -34,17 +34,17 @@ def cleanup_stack_if_exists(heat_client, template_name):
 @pytest.fixture
 def HeatStack(heatclientmanager, request):
     '''Fixture for creating/deleting a heat stack.'''
-    def manage_stack(template_file, template_name, parameters={}):
+    def manage_stack(template_file, stack_name, parameters={}):
         def teardown():
             heatclientmanager.delete_stack(stack.id)
 
-        template = get_template_file(template_file)
+        template = get_file_contents(template_file)
         config = {}
-        config['stack_name'] = template_name
+        config['stack_name'] = stack_name
         config['template'] = template
         config['parameters'] = parameters
         # Call delete before create, in case previous teardown failed
-        cleanup_stack_if_exists(heatclientmanager, template_name)
+        cleanup_stack_if_exists(heatclientmanager, stack_name)
         stack = heatclientmanager.create_stack(config)
         request.addfinalizer(teardown)
         return heatclientmanager, stack

--- a/f5_os_test/infrastructure.py
+++ b/f5_os_test/infrastructure.py
@@ -135,19 +135,19 @@ def setup_with_pool_member(setup_with_pool):
 
 @pytest.fixture
 def get_auth_config(request, keystoneclientmanager):
-    token = keystoneclientmanager.auth_ref['token']['id']
+    token_id = keystoneclientmanager.auth_ref['token']['id']
     auth_address = request.config.getoption('--auth-netloc')
     tenant_id = request.config.getoption('--os-tenant-id')
-    return token, auth_address, tenant_id
+    return token_id, auth_address, tenant_id
 
 
 @pytest.fixture
 def heatclientmanager(heatclient_pollster, get_auth_config):
     '''Heat client manager fixture.'''
-    token, auth_address, tenant_id = get_auth_config
+    token_id, auth_address, tenant_id = get_auth_config
     config_dict = {
         'endpoint': 'http://{0}:8004/v1/{1}'.format(auth_address, tenant_id),
-        'token': token
+        'token': token_id
     }
     return heatclient_pollster(**config_dict)
 

--- a/f5_os_test/infrastructure.py
+++ b/f5_os_test/infrastructure.py
@@ -142,9 +142,7 @@ def get_auth_config(request, keystoneclientmanager):
 
 
 @pytest.fixture
-def heatclientmanager(
-        request, keystoneclientmanager, heatclient_pollster, get_auth_config
-):
+def heatclientmanager(heatclient_pollster, get_auth_config):
     '''Heat client manager fixture.'''
     token, auth_address, tenant_id = get_auth_config
     config_dict = {
@@ -168,7 +166,7 @@ def keystoneclientmanager(request, keystoneclient_pollster):
 
 
 @pytest.fixture
-def glanceclientmanager(request, glanceclient_pollster, get_auth_config):
+def glanceclientmanager(glanceclient_pollster, get_auth_config):
     '''Glance client manager fixture.'''
     token, auth_address, _ = get_auth_config
     config_dict = {

--- a/f5_os_test/infrastructure.py
+++ b/f5_os_test/infrastructure.py
@@ -19,7 +19,7 @@ import pytest
 
 
 def pytest_addoption(parser):
-    parser.addoption("--bigip-address", action="store",
+    parser.addoption("--bigip-netloc", action="store",
                      help="BIG-IP hostname or IP address")
     parser.addoption("--bigip-username", action="store",
                      help="BIG-IP REST username",
@@ -27,7 +27,7 @@ def pytest_addoption(parser):
     parser.addoption("--bigip-password", action="store",
                      help="BIG-IP REST password",
                      default="admin")
-    parser.addoption("--auth-address", action="store",
+    parser.addoption("--auth-netloc", action="store",
                      help="Keystone Authorization server name, or IP address.")
     parser.addoption("--os-tenant-id", action="store",
                      help="ID for keystone tenant.")
@@ -42,7 +42,7 @@ def pytest_addoption(parser):
 @pytest.fixture
 def bigip(request, scope="module"):
     '''bigip fixture'''
-    opt_bigip = request.config.getoption("--bigip-address")
+    opt_bigip = request.config.getoption("--bigip-netloc")
     opt_username = request.config.getoption("--bigip-username")
     opt_password = request.config.getoption("--bigip-password")
     b = BigIP(opt_bigip, opt_username, opt_password)
@@ -52,7 +52,7 @@ def bigip(request, scope="module"):
 @pytest.fixture
 def nclientmanager(request, polling_neutronclient):
     auth_url = 'http://%s:5000/v2.0' %\
-        request.config.getoption('--auth-address')
+        request.config.getoption('--auth-netloc')
     nclient_config = {
         'username': 'testlab',
         'password': 'changeme',
@@ -136,7 +136,7 @@ def setup_with_pool_member(setup_with_pool):
 @pytest.fixture
 def get_auth_config(request, keystoneclientmanager):
     token = keystoneclientmanager.auth_ref['token']['id']
-    auth_address = request.config.getoption('--auth-address')
+    auth_address = request.config.getoption('--auth-netloc')
     tenant_id = request.config.getoption('--os-tenant-id')
     return token, auth_address, tenant_id
 
@@ -157,7 +157,7 @@ def heatclientmanager(
 @pytest.fixture
 def keystoneclientmanager(request, keystoneclient_pollster):
     '''Keystone client manager fixture.'''
-    auth_address = request.config.getoption('--auth-address')
+    auth_address = request.config.getoption('--auth-netloc')
     config_dict = {
         'auth_url': 'http://{}:5000/v2.0'.format(auth_address),
         'tenant_name': request.config.getoption('--os-tenant-name'),

--- a/f5_os_test/polling_clients.py
+++ b/f5_os_test/polling_clients.py
@@ -26,6 +26,7 @@ familiar enough with OS to make that leap.
 '''
 from f5.bigip import BigIP
 from glanceclient.v2.client import Client as GlanceClient
+from heatclient.exc import HTTPNotFound
 from heatclient.v1.client import Client as HeatClient
 from keystoneclient.v2_0.client import Client as KeystoneClient
 from neutronclient.common.exceptions import NotFound
@@ -383,10 +384,9 @@ class HeatClientPollingManager(HeatClient, ClientManagerMixin):
                 self.stack_status,
                 target_status='DELETE_COMPLETE'
             )
-        except Exception as ex:
-            if 'could not be found' not in ex:
-                raise
-        except MaximumNumberOfAttemptsExceeded as ex:
+        except HTTPNotFound:
+            raise
+        except MaximumNumberOfAttemptsExceeded:
             raise
 
 

--- a/f5_os_test/polling_clients.py
+++ b/f5_os_test/polling_clients.py
@@ -361,9 +361,6 @@ class HeatClientPollingManager(HeatClient, ClientManagerMixin):
 
         super(HeatClientPollingManager, self).__init__(**kwargs)
 
-    def _client(self):
-        return super(HeatClientPollingManager, self)
-
     def stack_status(self, stack):
         return stack.stack_status
 

--- a/f5_os_test/polling_clients.py
+++ b/f5_os_test/polling_clients.py
@@ -25,9 +25,12 @@ then we could probably effectively used such a decorator, but I'm not yet
 familiar enough with OS to make that leap.
 '''
 from f5.bigip import BigIP
+from glanceclient.v2.client import Client as GlanceClient
+from heatclient.v1.client import Client as HeatClient
+from keystoneclient.v2_0.client import Client as KeystoneClient
 from neutronclient.common.exceptions import NotFound
 from neutronclient.common.exceptions import StateInvalidClient
-from neutronclient.v2_0.client import Client
+from neutronclient.v2_0.client import Client as NeutronClient
 from pprint import pprint as pp
 import pytest
 import time
@@ -58,7 +61,12 @@ class PollingMixin(object):
         return current_state
 
 
-class NeutronClientPollingManager(Client, PollingMixin):
+class ClientManagerMixin(PollingMixin):
+    '''Base class for polling manager common functionality.'''
+    pass
+
+
+class NeutronClientPollingManager(NeutronClient, ClientManagerMixin):
     '''Invokes Neutronclient methods and polls for target expected states.'''
     def __init__(self, **kwargs):
         pp("got here in the constructor")
@@ -336,7 +344,92 @@ class NeutronClientPollingManager(Client, PollingMixin):
         return True
 
 
+class HeatClientPollingManager(HeatClient, ClientManagerMixin):
+    '''Utilizes heat client to create/delete heat stacks.'''
+
+    default_stack_config = {
+        'files': {},
+        'disable_rollback': True,
+        'environment': {},
+        'tags': None,
+        'environment_files': None
+    }
+
+    def __init__(self, **kwargs):
+        self.interval = kwargs.pop('interval', 10)
+        self.max_attempts = kwargs.pop('max_attempts', 100)
+
+        super(HeatClientPollingManager, self).__init__(**kwargs)
+
+    def _client(self):
+        return super(HeatClientPollingManager, self)
+
+    def stack_status(self, stack):
+        return stack.stack_status
+
+    def create_stack(self, configuration):
+        configuration.update(self.default_stack_config)
+        stack = self.stacks.create(**configuration)
+        return self.poll(
+            self.stacks.get,
+            stack['stack']['id'],
+            self.stack_status,
+            target_status='CREATE_COMPLETE'
+        )
+
+    def delete_stack(self, stack_id):
+        self.stacks.delete(stack_id)
+        try:
+            self.poll(
+                self.stacks.get,
+                stack_id,
+                self.stack_status,
+                target_status='DELETE_COMPLETE'
+            )
+        except Exception as ex:
+            if 'could not be found' not in ex:
+                raise
+        except MaximumNumberOfAttemptsExceeded as ex:
+            raise
+
+
+class KeystoneClientPollingManager(KeystoneClient, ClientManagerMixin):
+    '''Manager for keystone client polling.'''
+
+    def __init__(self, **kwargs):
+        self.interval = kwargs.pop('interval', 2)
+        self.max_attempts = kwargs.pop('max_attempts', 20)
+
+        super(KeystoneClientPollingManager, self).__init__(**kwargs)
+
+
+class GlanceClientPollingManager(GlanceClient, ClientManagerMixin):
+    def __init__(self, **kwargs):
+        self.interval = kwargs.pop('interval', 2)
+        self.max_attempts = kwargs.pop('max_attempts', 20)
+
+        super(GlanceClientPollingManager, self).__init__(**kwargs)
+
+
 @pytest.fixture
 def polling_neutronclient():
     '''Invokes Neutronclient methods and polls for target expected states.'''
     return NeutronClientPollingManager
+
+
+@pytest.fixture
+def heatclient_pollster():
+    '''Access to HeatClient polling for create/delete/modify of heat stack.'''
+    return HeatClientPollingManager
+
+
+@pytest.fixture
+def keystoneclient_pollster():
+    '''Access to KeystoneClient pollster.'''
+    return KeystoneClientPollingManager
+
+
+@pytest.fixture
+def glanceclient_pollster():
+    '''Access to GlanceClient pollster for managing images.'''
+    return GlanceClientPollingManager

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,15 @@ setup(
                       'pytest-cov >= 2.2.1',
                       'mock >= 1.3.0',
                       'f5-sdk >= 0.1.3',
-                      'python-neutronclient >= 4.1.2.dev5'],
+                      'python-neutronclient >= 4.1.2.dev5',
+                      'python-keystoneclient >= 2.3.1',
+                      'python-heatclient >= 1.1.0',
+                      'python-glanceclient >= 2.0.0'],
     packages=['f5_os_test'],
     entry_points={
         'pytest11': ['poll_fix = f5_os_test.polling_clients',
-                     'infra_fix = f5_os_test.infrastructure']
+                     'infra_fix = f5_os_test.infrastructure',
+                     'heat_utils = f5_os_test.heat_client_utils']
     },
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
@zancas 

Issues: Fixes #28

Problem: More fixtures are needed to allow use of other openstack
clients such as the heatclient, glanceclient, and keystoneclient.

Analysis: Added fixtures for each of the above clients, as well as
pollsters to allow for easy access to the clients via the fixtures. The
pollsters subclass the clients themselves and therefore can do anything
the clients can do.

Tests: All tests were run from the f5-heat repo, using these fixtures.
