### PR TITLE
Changes to infrastructure.py to accept data from symbols and not from…

### DIFF
--- a/f5_os_test/__init__.py
+++ b/f5_os_test/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = '0.1.3'
+__version__ = '0.2.0'

--- a/f5_os_test/infrastructure.py
+++ b/f5_os_test/infrastructure.py
@@ -120,7 +120,7 @@ def setup_with_healthmonitor(setup_with_pool_member):
 
 
 @pytest.fixture
-def get_auth_token(symbols, keystoneclientmanager):
+def get_auth_token(keystoneclientmanager):
     token_id = keystoneclientmanager.auth_ref['token']['id']
     return token_id
 


### PR DESCRIPTION
… command line
@dflanigan @szakeri  

What issues does this address?

Fixes #37
WIP #

The goal was to eliminate the command line options for environmental data and to use symols data instead.  

Note that only lbaasv2 testing uses this repository, and the test_env.json file required for this change is that for test/functional in f5-openstack-lbaasv2-driver; however, any json file with the referenced keys can be used here with symbols by other projects.
