### PR TITLE
Heat client fixture needs to support a parameter for expected target stack status

### DIFF
--- a/f5_os_test/heat_client_utils.py
+++ b/f5_os_test/heat_client_utils.py
@@ -41,7 +41,7 @@ def HeatStack(heatclientmanager, request):
             teardown=True,
             expect_fail=False
     ):
-        def teardown():
+        def test_teardown():
             heatclientmanager.delete_stack(stack.id)
 
         template = get_file_contents(template_file)
@@ -59,6 +59,6 @@ def HeatStack(heatclientmanager, request):
             target_status=target_status
         )
         if teardown:
-            request.addfinalizer(teardown)
+            request.addfinalizer(test_teardown)
         return heatclientmanager, stack
     return manage_stack

--- a/f5_os_test/heat_client_utils.py
+++ b/f5_os_test/heat_client_utils.py
@@ -34,7 +34,13 @@ def cleanup_stack_if_exists(heat_client, template_name):
 @pytest.fixture
 def HeatStack(heatclientmanager, request):
     '''Fixture for creating/deleting a heat stack.'''
-    def manage_stack(template_file, stack_name, parameters={}):
+    def manage_stack(
+            template_file,
+            stack_name,
+            parameters={},
+            teardown=True,
+            expect_fail=False
+    ):
         def teardown():
             heatclientmanager.delete_stack(stack.id)
 
@@ -45,7 +51,14 @@ def HeatStack(heatclientmanager, request):
         config['parameters'] = parameters
         # Call delete before create, in case previous teardown failed
         cleanup_stack_if_exists(heatclientmanager, stack_name)
-        stack = heatclientmanager.create_stack(config)
-        request.addfinalizer(teardown)
+        target_status = 'CREATE_COMPLETE'
+        if expect_fail:
+            target_status = 'CREATE_FAILED'
+        stack = heatclientmanager.create_stack(
+            config,
+            target_status=target_status
+        )
+        if teardown:
+            request.addfinalizer(teardown)
         return heatclientmanager, stack
     return manage_stack

--- a/f5_os_test/infrastructure.py
+++ b/f5_os_test/infrastructure.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-from f5.bigip import BigIP
+from f5.bigip import ManagementRoot
 from pprint import pprint as pp
 import pytest
 
@@ -21,7 +21,9 @@ import pytest
 @pytest.fixture
 def bigip(symbols, scope="module"):
     '''bigip fixture'''
-    return BigIP(symbols.bigip_ip, symbols.bigip_username, symbols.bigip_password)
+    return ManagementRoot(
+        symbols.bigip_ip, symbols.bigip_username, symbols.bigip_password
+    )
 
 
 @pytest.fixture

--- a/f5_os_test/polling_clients.py
+++ b/f5_os_test/polling_clients.py
@@ -365,14 +365,14 @@ class HeatClientPollingManager(HeatClient, ClientManagerMixin):
     def stack_status(self, stack):
         return stack.stack_status
 
-    def create_stack(self, configuration):
+    def create_stack(self, configuration, target_status='CREATE_COMPLETE'):
         configuration.update(self.default_stack_config)
         stack = self.stacks.create(**configuration)
         return self.poll(
             self.stacks.get,
             stack['stack']['id'],
             self.stack_status,
-            target_status='CREATE_COMPLETE'
+            target_status=target_status
         )
 
     def delete_stack(self, stack_id):


### PR DESCRIPTION
@szakeri 

Issues:
Fixes #40

Problem:
In order to extend these fixtures to work with the
f5-openstack-heat-plugins functional tests, we need to expect a stack to
fail. One way we do this is to create a stack and expect the status to
be 'CREATED_FAILED'. So we will allow a new parameter when creating a
stack which is the expect target status.

Analysis:
Added the default target status to 'CREATE_COMPLETE' and allowed a
consumer to pass in their expected status.

Tests:
Ran tests against the f5-openstack-heat-plugins repo with success
