### PR TITLE
More resources need to be ordered in agent teardown

### DIFF
--- a/f5_os_test/order_utils.py
+++ b/f5_os_test/order_utils.py
@@ -22,11 +22,13 @@ AGENT_LB_DEL_ORDER = {'/mgmt/tm/ltm/virtual':           1,
                       'mgmt/tm/net/self/':              6,
                       '/mgmt/tm/net/fdb':               7,
                       'mgmt/tm/net/tunnels/tunnel/':    8,
-                      'route':                          9,
-                      '/mgmt/tm/ltm/snatpool':         10,
-                      '/mgmt/tm/ltm/snat-translation': 11,
-                      '/mgmt/tm/net/route-domain':     12,
-                      '/mgmt/tm/sys/folder':           13}
+                      'mgmt/tm/net/tunnels/vxlan/':     9,
+                      'mgmt/tm/net/tunnels/gre':       10,
+                      'route':                         11,
+                      '/mgmt/tm/ltm/snatpool':         12,
+                      '/mgmt/tm/ltm/snat-translation': 13,
+                      '/mgmt/tm/net/route-domain':     14,
+                      '/mgmt/tm/sys/folder':           15}
 
 
 def order_by_weights(unordered, weights_table):

--- a/f5_os_test/order_utils.py
+++ b/f5_os_test/order_utils.py
@@ -14,14 +14,19 @@
 #
 
 
-AGENT_LB_DEL_ORDER = {'/mgmt/tm/ltm/virtual': 1,
-                      '/mgmt/tm/ltm/pool': 2,
-                      'mgmt/tm/ltm/node/': 3,
-                      'monitor': 4,
-                      'virtual-address': 5,
-                      '/mgmt/tm/net/fdb/tunnel': 6,
-                      'mgmt/tm/net/tunnels/tunnel/': 7,
-                      '/mgmt/tm/sys/folder': 8}
+AGENT_LB_DEL_ORDER = {'/mgmt/tm/ltm/virtual':           1,
+                      '/mgmt/tm/ltm/pool':              2,
+                      'mgmt/tm/ltm/node/':              3,
+                      'monitor':                        4,
+                      'virtual-address':                5,
+                      'mgmt/tm/net/self/':              6,
+                      '/mgmt/tm/net/fdb':               7,
+                      'mgmt/tm/net/tunnels/tunnel/':    8,
+                      'route':                          9,
+                      '/mgmt/tm/ltm/snatpool':         10,
+                      '/mgmt/tm/ltm/snat-translation': 11,
+                      '/mgmt/tm/net/route-domain':     12,
+                      '/mgmt/tm/sys/folder':           13}
 
 
 def order_by_weights(unordered, weights_table):
@@ -36,12 +41,12 @@ def order_by_weights(unordered, weights_table):
     >>> order_by_weights([URI1, URI2, ...], AGENT_LB_DEL_ORDER)
     [URI2, URI1, ....]
     '''
-    max_plus_one = max(weights_table.values()) + 1
+    min_minus_one = min(weights_table.values()) - 1
 
     def order_key(item):
         for k in weights_table:
             if k in item:
                 return weights_table[k]
-        return max_plus_one
+        return min_minus_one
     ordered_by_weights = sorted(list(unordered), key=order_key)
     return ordered_by_weights

--- a/f5_os_test/polling_clients.py
+++ b/f5_os_test/polling_clients.py
@@ -71,7 +71,7 @@ class NeutronClientPollingManager(NeutronClient, ClientManagerMixin):
     '''Invokes Neutronclient methods and polls for target expected states.'''
     def __init__(self, **kwargs):
         pp("got here in the constructor")
-        self.interval = kwargs.pop('interval', .4)
+        self.interval = kwargs.pop('interval', 2)
         self.max_attempts = kwargs.pop('max_attempts', 12)
         super(NeutronClientPollingManager, self).__init__(**kwargs)
 
@@ -108,13 +108,6 @@ class NeutronClientPollingManager(NeutronClient, ClientManagerMixin):
             return True
         return False
 
-    def update_loadbalancer(self, lbid, lbconf):
-        updated = self._poll_call_with_exceptions(
-            StateInvalidClient,
-            super(NeutronClientPollingManager, self).update_loadbalancer,
-            lbid, lbconf)
-        return updated
-
     def delete_loadbalancer(self, lbid):
         attempts = 0
         while not self._lb_delete_helper(lbid):
@@ -123,6 +116,13 @@ class NeutronClientPollingManager(NeutronClient, ClientManagerMixin):
             if attempts > self.max_attempts:
                 raise MaximumNumberOfAttemptsExceeded
         return True
+
+    def update_loadbalancer(self, lbid, lbconf):
+        updated = self._poll_call_with_exceptions(
+            StateInvalidClient,
+            super(NeutronClientPollingManager, self).update_loadbalancer,
+            lbid, lbconf)
+        return updated
 
     def delete_all_loadbalancers(self):
         for lb in super(NeutronClientPollingManager, self)\


### PR DESCRIPTION
@mattgreene 
Issues:
Fixes #56

Problem:  When test teardown runs device resource must be cleaned up in a particular order.

Analysis: The earlier version of AGENT_LB_DEL_ORDER ommitted some resources that need to be
deleted in order during undercloud-device teardown.   Additionally any non-matched resource will be pushed to the _FRONT_ of the ordered list.   That is, if nothing depends on a resource it is deleted _before_ the resources with dependencies are addressed.

Tests:  the `test_disconnected_services.py` suite in `f5-openstack-agent` depends on this utility
