### PR TITLE
rm bigip fixture

### DIFF
--- a/f5_os_test/__init__.py
+++ b/f5_os_test/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/f5_os_test/infrastructure.py
+++ b/f5_os_test/infrastructure.py
@@ -13,17 +13,7 @@
 # limitations under the License.
 #
 
-from f5.bigip import ManagementRoot
-from pprint import pprint as pp
 import pytest
-
-
-@pytest.fixture
-def bigip(symbols, scope="module"):
-    '''bigip fixture'''
-    return ManagementRoot(
-        symbols.bigip_ip, symbols.bigip_username, symbols.bigip_password
-    )
 
 
 @pytest.fixture
@@ -41,7 +31,6 @@ def nclientmanager(symbols, polling_neutronclient):
 @pytest.fixture
 def setup_with_nclientmanager(request, nclientmanager):
     def finalize():
-        pp('Entered setup/finalize.')
         nclientmanager.delete_all_lbaas_healthmonitors()
         nclientmanager.delete_all_lbaas_pools()
         nclientmanager.delete_all_listeners()

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
                       'pytest >= 2.9.1',
                       'pytest-cov >= 2.2.1',
                       'mock >= 1.3.0',
-                      'f5-sdk >= 2.1.0',
+                      'f5-sdk >= 2',
                       'python-neutronclient >= 2.3.11',
                       'python-keystoneclient >= 2.3.1',
                       'python-heatclient >= 0.3.0',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
                       'pytest >= 2.9.1',
                       'pytest-cov >= 2.2.1',
                       'mock >= 1.3.0',
-                      'f5-sdk >= 0.1.7',
+                      'f5-sdk >= 2.1.0',
                       'python-neutronclient >= 2.3.11',
                       'python-keystoneclient >= 2.3.1',
                       'python-heatclient >= 0.3.0',


### PR DESCRIPTION
@pjbreaux 
Issues:
Fixes #62

Problem: We have many sources of truth repeating themselves
for single components of our system.

Analysis:  Part of the fix is to roll all code specific
test enhancements, like fixtures that are used by pytest
to expose elements of the system under test, like "bigip"
into the codebase that they are exposing (f5-common-python in
this case).