### PR TITLE
f5-sdk dependency in liberty and mitaka is woefully out of date

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     keywords=['F5', 'openstack', 'test'],
     install_requires=['pytest == 2.9.1',
                       'pytest-cov == 2.2.1',
-                      'f5-sdk == 0.1.7',
+                      'f5-sdk == 2.2.2',
                       'python-neutronclient == 3.1.1',
                       'python-keystoneclient == 1.7.2',
                       'python-heatclient == 0.8.0',


### PR DESCRIPTION
Issues:
Fixes #68

Problem:
To keep up with current testing in the driver, we need to bump the
required sdk version in setup.py here to ensure it's keeping up with
current releases for testing.

Analysis:
Modified the requirement to f5-sdk >= 2.2.2, < 3

Tests:
Ran test locally on my buildbot sandbox