### PR TITLE
Set sdk deps to pinned version based on agent requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     keywords=['F5', 'openstack', 'test'],
     install_requires=['pytest == 2.9.1',
                       'pytest-cov == 2.2.1',
-                      'f5-sdk == 2.2.2',
+                      'f5-sdk == 2.3.1',
                       'python-neutronclient == 3.1.1',
                       'python-keystoneclient == 1.7.2',
                       'python-heatclient == 0.8.0',


### PR DESCRIPTION
Issues:
Fixes #72

Problem:
The agent requires a certain version of the sdk when it is installed.
This same version should be used when running tests. We are setting the
required sdk version to 2.3.1 in accordance with the latest release of
the sdk and the agent.

Analysis:
Modified the setup.py to set f5-sdk to version 2.3.1

Tests:
Installed the f5-openstack-test repo and verified 2.3.1 is installed
version of the sdk.