### PR TITLE
Keystoneclient dependencies are incorrect for stable/newton branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
                       'pytest-cov == 2.2.1',
                       'f5-sdk == 2.3.1',
                       'python-neutronclient == 6.0.0',
-                      'python-keystoneclient == 3.5.0',
+                      'python-keystoneclient == 3.5.1',
                       'python-heatclient == 1.5.0',
                       'python-glanceclient == 2.5.0',
                       'iso8601 == 0.1.11'],


### PR DESCRIPTION
@jlongstaf 

Issues:
Fixes #77

Problem:
Based on the upper constraints file, the python-keystoneclient
dependency in setup.py for newton should be 3.5.1, but it is currently
3.5.0 in stable/newton.

Analysis:
Changed the keystone dependency to 3.5.1

Tests:
Testing travis deployment on my local fork.