### PR TITLE
Python-heatclient dependency is incorrect for stable/newton

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
                       'f5-sdk == 2.3.1',
                       'python-neutronclient == 6.0.0',
                       'python-keystoneclient == 3.5.1',
-                      'python-heatclient == 1.5.0',
+                      'python-heatclient == 1.5.1',
                       'python-glanceclient == 2.5.0',
                       'iso8601 == 0.1.11'],
     packages=['f5_os_test'],


### PR DESCRIPTION
Issues:
Fixes #82

Problem:
The python-heatclient in setup.py is pinned to 1.5.0, yet the upper
constraints file for openstack:

https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/newton

Pins that version to 1.5.1. We should bump to that version in this
setup.py.

Analysis:
Updated the version to 1.5.1

Tests:
Ran tests against newton stack in my jenkins environment. Got past the version conflicts I was seeing when running this with jenkins.

```
+ touch /home/testlab/f5-openstack-lbaasv2-driver/systest//../f5lbaasdriver/test/tempest/tests/.pytest.rootdir
+ touch /home/jenkins/neutron-lbaas/neutron_lbaas/tests/tempest/v2/.pytest.rootdir
+ cd /home/testlab/f5-openstack-lbaasv2-driver/systest//../
+ tox --sitepackages -e tempest -c tox.ini -- --meta /home/testlab/f5-openstack-lbaasv2-driver/systest//exclude//tempest_12.1.1_undercloud_vlan.yaml -lvv --autolog-outputdir /home/testlab/f5-openstack-lbaasv2-driver/systest//test_results/f5-openstack-lbaasv2-driver_stablenewton-tempest_12.1.1_undercloud_vlan --autolog-session driver.tempest_683c0a6_20170609-144515
GLOB sdist-make: /home/testlab/f5-openstack-lbaasv2-driver/setup.py
tempest create: /home/testlab/f5-openstack-lbaasv2-driver/.tox/tempest
tempest installdeps: -rrequirements.test.txt
WARNING:Discarding $PYTHONPATH from environment, to override specify PYTHONPATH in 'passenv' in your configuration.
tempest inst: /home/testlab/f5-openstack-lbaasv2-driver/.tox/dist/f5-openstack-lbaasv2-driver-9.3.1.zip
tempest installed: The directory '/home/buildbot/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.,alembic==0.8.7,amqp==1.4.9,anyjson==0.3.3,appdirs==1.4.0,argcomplete==1.8.2,asn1crypto==0.22.0,astroid==1.5.2,attrs==16.3.0,Automat==0.5.0,Babel==2.3.4,backports.functools-lru-cache==1.3,backports.shutil-get-terminal-size==1.0.0,backports.ssl-match-hostname==3.5.0.1,beautifulsoup4==4.5.1,blessings==1.6,buildbot-slave==0.8.12,cachetools==1.1.6,cffi==1.7.0,cliff==2.2.0,cmd2==0.6.8,colorama==0.3.7,ConfigArgParse==0.12.0,configparser==3.5.0,constantly==15.1.0,contextlib2==0.5.4,coverage==4.2,cryptography==1.5,debtcollector==1.8.0,decorator==4.0.10,deprecation==1.0.1,docopt==0.6.2,dogpile.cache==0.6.2,ecdsa==0.13,enum34==1.1.6,eventlet==0.19.0,extras==1.0.0,f5-icontrol-rest==1.3.0,f5-openstack-agent==9.3.1b1,-e git+https://github.com/pjbreaux/f5-openstack-lbaasv2-driver.git@683c0a6f417a46c446fbb106c44348b919e8351d#egg=f5_openstack_lbaasv2_driver,f5-openstack-test==0.2.1,f5-sdk==2.3.1,Fabric==1.13.1,fasteners==0.14.1,fixtures==3.0.0,flake8==2.6.2,funcsigs==1.0.2,functools32==3.2.3.post2,futures==3.0.5,futurist==0.18.0,greenlet==0.4.10,httplib2==0.9.2,idna==2.1,incremental==16.10.1,ipaddress==1.0.16,iso8601==0.1.11,isort==4.2.5,Jinja2==2.8,jsonpatch==1.14,jsonpointer==1.10,jsonschema==2.5.1,keystoneauth1==2.12.3,keystonemiddleware==4.9.1,kombu==3.0.35,lazy-object-proxy==1.2.2,linecache2==1.0.0,logutils==0.3.3,Mako==1.0.4,marathon==0.8.10,MarkupSafe==0.23,mccabe==0.5.3,mock==2.0.0,monotonic==1.2,msgpack-python==0.4.8,netaddr==0.7.18,netifaces==0.10.5,neutron==9.4.1.dev8,neutron-lbaas==9.2.1.dev13,neutron-lib==0.4.0,oauth2client==4.0.0,oauthlib==2.0.2,openstacksdk==0.9.16,os-client-config==1.21.1,os-testr==0.8.0,osc-lib==1.1.0,oslo.cache==1.14.0,oslo.concurrency==3.14.0,oslo.config==3.17.1,oslo.context==2.9.0,oslo.db==4.13.5,oslo.i18n==3.9.0,oslo.log==3.16.0,oslo.messaging==5.10.1,oslo.middleware==3.19.1,oslo.policy==1.14.0,oslo.reports==1.14.0,oslo.rootwrap==5.1.1,oslo.serialization==2.13.0,oslo.service==1.16.0,oslo.utils==3.16.0,oslo.versionedobjects==1.17.0,osprofiler==1.4.0,ovs==2.5.0,packaging==16.8,paramiko==2.0.2,Paste==2.0.3,PasteDeploy==1.5.2,pbr==1.10.0,pecan==1.1.2,pep257==0.7.0,pexpect==4.0.1,pika==0.10.0,pika-pool==0.1.3,positional==1.1.1,prettytable==0.7.2,protobuf==2.6.1,psutil==1.2.1,ptyprocess==0.5,py==1.4.31,pyasn1==0.1.9,pyasn1-modules==0.0.8,pycadf==2.4.0,pycodestyle==2.0.0,pycparser==2.14,pycrypto==2.6.1,pyflakes==1.2.3,pyinotify==0.9.6,pykube==0.14.0,pylint==1.7.1,pyOpenSSL==16.1.0,pyparsing==2.1.10,pytest==3.0.1,pytest-autolog==0.1.0a3,pytest-cov==2.2.1,pytest-meta==0.1.1,pytest-symbols==0.1.0a3,python-barbicanclient==4.0.1,python-cinderclient==2.0.1,python-dateutil==2.5.3,python-designateclient==2.3.0,python-editor==1.0.1,python-glanceclient==2.5.0,python-heatclient==1.5.1,python-keystoneclient==3.5.1,python-mimeparse==1.5.2,python-neutronclient==6.0.0,python-novaclient==6.0.1,python-openstackclient==3.6.0,python-subunit==1.2.0,python-swiftclient==3.1.0,pytz==2016.6.1,PyYAML==3.12,rcli==0.2.5,repoze.lru==0.6,requests==2.11.1,requests-oauthlib==0.8.0,requestsexceptions==1.1.3,retrying==1.3.3,rfc3986==0.4.1,Routes==2.3.1,rsa==3.4.2,ryu==4.5,schema==0.6.5,simplejson==3.8.2,singledispatch==3.4.0.3,six==1.10.0,splunk-sdk==1.6.2,SQLAlchemy==1.0.14,sqlalchemy-migrate==0.10.0,sqlparse==0.2.1,stevedore==1.17.1,systest-common==0.2.9,tempest==12.1.0,Tempita==0.5.2,testenv==0.2.1,testenv-openstack==0.1.2,testrepository==0.0.20,testscenarios==0.5.0,testtools==2.2.0,tlc-client==0.11.4,tqdm==4.11.2,traceback2==1.4.0,Twisted==17.1.0,typing==3.6.1,tzlocal==1.4,unicodecsv==0.14.1,unittest2==1.1.0,urllib3==1.16,virtualenv==15.1.0,virtualenv-clone==0.2.6,virtualenvwrapper==4.7.2,waitress==1.0.0,warlock==1.2.0,WebOb==1.6.1,WebTest==2.0.23,wrapt==1.10.8,zope.interface==4.4.0
tempest runtests: PYTHONHASHSEED='2983518842'
tempest runtests: commands[0] | py.test -vra --meta ../../../../systest/exclude/tempest_12.1.1_undercloud_vlan.yaml -lvv --autolog-outputdir /home/testlab/f5-openstack-lbaasv2-driver/systest//test_results/f5-openstack-lbaasv2-driver_stablenewton-tempest_12.1.1_undercloud_vlan --autolog-session driver.tempest_683c0a6_20170609-144515
<class 'f5.bigip.BigIP'>
=============================================================================================== test session starts ===============================================================================================
platform linux2 -- Python 2.7.12, pytest-3.0.1, py-1.4.31, pluggy-0.3.1 -- /home/testlab/f5-openstack-lbaasv2-driver/.tox/tempest/bin/python
cachedir: ../../../../.cache
pytest-autolog: outputdir is /home/testlab/f5-openstack-lbaasv2-driver/systest/test_results/f5-openstack-lbaasv2-driver_stablenewton-tempest_12.1.1_undercloud_vlan/driver.tempest_683c0a6_20170609-144515
pytest-autolog: trace is disabled
rootdir: /home/testlab/f5-openstack-lbaasv2-driver, inifile:
plugins: cov-2.2.1, f5-sdk-2.3.1, f5-openstack-test-0.2.1, symbols-0.1.0a3, meta-0.1.1, autolog-0.1.0a3
collected 45 items
pytest-meta: discarded 0 items
```